### PR TITLE
FileLink: accept path-like objects (#11059)

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -3,7 +3,7 @@
 Authors : MinRK, gregcaporaso, dannystaple
 """
 from os.path import exists, isfile, splitext, abspath, join, isdir
-from os import walk, sep
+from os import walk, sep, fsdecode
 
 from IPython.core.display import DisplayObject
 
@@ -334,7 +334,7 @@ class FileLink(object):
         if isdir(path):
             raise ValueError("Cannot display a directory using FileLink. "
               "Use FileLinks to display '%s'." % path)
-        self.path = path
+        self.path = fsdecode(path)
         self.url_prefix = url_prefix
         self.result_html_prefix = result_html_prefix
         self.result_html_suffix = result_html_suffix


### PR DESCRIPTION
Accept path-like objects by converting them to strings using `os.fsdecode`.

From the Python 3 [glossary][1]:
> `os.fsdecode()` and `os.fsencode()` can be used to guarantee a `str`
> or `bytes` result

N.B. `os.fsdecode` accepts path-like objects starting with Python 3.6,
so users of older versions still can't use FileLink with path-like
objects.

[1]: https://docs.python.org/3/glossary.html#term-path-like-object